### PR TITLE
Expose a nom-compatible version of parse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn parse<'a>(input: &'a str) -> Result<Value, Box<dyn Error + 'a>> {
     Ok(result)
 }
 
-fn json(input: &str) -> IResult<&str, Value> {
+pub fn json(input: &str) -> IResult<&str, Value> {
     element(input)
 }
 


### PR DESCRIPTION
Having a function that parses json mid-stream would be quite handy.
I've already got a large `nom` parser which can have JSON leaves, it would be nice to not have to write and maintain a whole JSON parser as part of my service.

Thank you!